### PR TITLE
Unbond & Withdraw Rewards in dashboard

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,3 @@
+nodeLinker: node-modules
+
+yarnPath: .yarn/releases/yarn-1.22.1.cjs

--- a/chains/mainnet/hippo-protocol.json
+++ b/chains/mainnet/hippo-protocol.json
@@ -1,0 +1,24 @@
+{
+  "chain_name": "hippo-protocol",
+  "api": [
+    "https://api.testnet.hippo-protocol.com"
+  ],
+  "rpc": [
+    "https://rpc.testnet.hippo-protocol.com"
+  ],
+  "snapshot_provider": "",
+  "sdk_version": "0.47.12",
+  "coin_type": "0",
+  "min_tx_fee": "1000000000000000000",
+  "addr_prefix": "hippo",
+  "logo": "/logos/hippo-protocol.png",
+  "assets": [
+    {
+      "base": "ahp",
+      "symbol": "HP",
+      "exponent": "18",
+      "coingecko_id": "",
+      "logo": "/logos/hippo-protocol.png"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@chenfengyuan/vue-countdown": "2",
-    "@cosmjs/crypto": "^0.32.3",
     "@cosmjs/amino": "^0.32.3",
+    "@cosmjs/crypto": "^0.32.3",
     "@cosmjs/encoding": "^0.32.3",
     "@cosmjs/stargate": "^0.32.3",
     "@iconify/vue": "^4.1.0",
@@ -75,5 +75,6 @@
     "vite-plugin-pages": "^0.28.0",
     "vue-json-viewer": "3",
     "vue-tsc": "^1.0.12"
-  }
+  },
+  "packageManager": "yarn@1.22.1"
 }

--- a/src/modules/[chain]/index.vue
+++ b/src/modules/[chain]/index.vue
@@ -361,10 +361,6 @@ const amount = computed({
                     @click="dialog.open('delegate', { validator_address: item.delegation.validator_address }, updateState)">
                     {{ $t('account.btn_delegate') }}
                   </label>
-                  <label for="withdraw" class="btn !btn-xs !btn-primary btn-ghost rounded-sm mr-2"
-                    @click="dialog.open('withdraw', { validator_address: item.delegation.validator_address }, updateState)">
-                    {{ $t('index.btn_withdraw_reward') }}
-                  </label>
                   <label
                     for="unbond"
                     class="btn !btn-xs !btn-primary btn-ghost rounded-sm"
@@ -386,11 +382,17 @@ const amount = computed({
         </table>
       </div>
 
-      <div class="grid grid-cols-3 gap-4 px-4 pb-6 mt-4">
+      <div class="grid grid-cols-4 gap-4 px-4 pb-6 mt-4">
         <label for="PingTokenConvert" class="btn btn-primary text-white">{{ $t('index.btn_swap') }}</label>
         <label for="send" class="btn !bg-yes !border-yes text-white" @click="dialog.open('send', {}, updateState)">{{ $t('account.btn_send') }}</label>
         <label for="delegate" class="btn !bg-info !border-info text-white"
           @click="dialog.open('delegate', {}, updateState)">{{ $t('account.btn_delegate') }}</label>
+          <label
+            for="withdraw"
+            class="btn !bg-lime-500 !border-info text-white"
+            @click="dialog.open('withdraw', {}, updateState)"
+            >{{ $t('index.btn_withdraw_reward') }}</label
+          >
         <RouterLink to="/wallet/receive" class="btn !bg-info !border-info text-white hidden">{{ $t('index.receive') }}</RouterLink>
       </div>
       <Teleport to="body">

--- a/src/modules/[chain]/index.vue
+++ b/src/modules/[chain]/index.vue
@@ -361,10 +361,24 @@ const amount = computed({
                     @click="dialog.open('delegate', { validator_address: item.delegation.validator_address }, updateState)">
                     {{ $t('account.btn_delegate') }}
                   </label>
-                  <label for="withdraw" class="btn !btn-xs !btn-primary btn-ghost rounded-sm"
+                  <label for="withdraw" class="btn !btn-xs !btn-primary btn-ghost rounded-sm mr-2"
                     @click="dialog.open('withdraw', { validator_address: item.delegation.validator_address }, updateState)">
                     {{ $t('index.btn_withdraw_reward') }}
                   </label>
+                  <label
+                    for="unbond"
+                    class="btn !btn-xs !btn-primary btn-ghost rounded-sm"
+                    @click="
+                      dialog.open(
+                        'unbond',
+                        {
+                          validator_address: item.delegation.validator_address,
+                        },
+                        updateState
+                      )
+                    "
+                    >{{ $t('account.btn_unbond') }}</label
+                  >
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
- Unbond button per validator in dashboard
- Withdraw all rewards in dashboard

As I add `withdraw rewards` button which collect all rewards from all validators , I removed withdraw button for each validators.


@ChrisCho-H I think `SWAP` not working in our network. Do I need to remove?

![image](https://github.com/user-attachments/assets/63d1241e-8a9e-44ce-8f97-c47a8f94994f)
