### PR TITLE
Add explorer features

### DIFF
--- a/src/layouts/components/DefaultLayout.vue
+++ b/src/layouts/components/DefaultLayout.vue
@@ -23,7 +23,7 @@ const blockchain = useBlockchain();
 blockchain.randomSetupEndpoint();
 const baseStore = useBaseStore();
 
-const current = ref(''); // the current chain
+const current = ref('hippo-protocol'); // the current chain
 const temp = ref('')
 blockchain.$subscribe((m, s) => {
   if(current.value ===s.chainName && temp.value != s.endpoint.address) {

--- a/src/libs/api/index.ts
+++ b/src/libs/api/index.ts
@@ -1,7 +1,4 @@
-import {
-  type RequestRegistry,
-  adapter,
-} from './registry';
+import { type RequestRegistry, adapter } from './registry';
 
 export const DEFAULT: RequestRegistry = {
   auth_params: { url: '/cosmos/auth/v1beta1/params', adapter },
@@ -10,7 +7,10 @@ export const DEFAULT: RequestRegistry = {
     url: '/cosmos/auth/v1beta1/accounts/{address}',
     adapter,
   },
-  params: { url: '/cosmos/params/v1beta1/params?subspace={subspace}&key={key}', adapter },
+  params: {
+    url: '/cosmos/params/v1beta1/params?subspace={subspace}&key={key}',
+    adapter,
+  },
   bank_params: { url: '/cosmos/bank/v1beta1/params', adapter },
   bank_balances_address: {
     url: '/cosmos/bank/v1beta1/balances/{address}',
@@ -201,6 +201,12 @@ export const DEFAULT: RequestRegistry = {
   },
   interchain_security_consumer_validators: {
     url: '/interchain_security/ccv/provider/consumer_validators/{chain_id}',
+    adapter,
+  },
+
+  // hippo RPC
+  block_by_height: {
+    url: 'https://rpc.testnet.hippo-protocol.com/blockchain?minHeight={minHeight}&maxHeight={maxHeight}',
     adapter,
   },
 };

--- a/src/libs/api/registry.ts
+++ b/src/libs/api/registry.ts
@@ -1,6 +1,7 @@
 import type {
   AuthAccount,
   Block,
+  BlocksByHeight,
   ClientStateWithProof,
   Coin,
   ConnectionWithProof,
@@ -42,7 +43,7 @@ import type {
   Validator,
 } from '@/types/staking';
 import type { PaginatedTxs, Tx, TxResponse } from '@/types';
-import semver from 'semver'
+import semver from 'semver';
 export interface Request<T> {
   url: string;
   adapter: (source: any) => Promise<T>;
@@ -75,10 +76,10 @@ export interface RequestRegistry extends AbstractRegistry {
   distribution_community_pool: Request<{ pool: Coin[] }>;
   distribution_delegator_rewards: Request<{
     rewards: {
-      validator_address: string, 
-      reward: Coin[]
-    }[],
-    total: Coin[]
+      validator_address: string;
+      reward: Coin[];
+    }[];
+    total: Coin[];
   }>;
 
   mint_inflation: Request<{ inflation: string }>;
@@ -90,7 +91,7 @@ export interface RequestRegistry extends AbstractRegistry {
   }>;
   mint_annual_provisions: Request<{ annual_provisions: string }>;
 
-  slashing_params: Request<{params: SlashingParam}>;
+  slashing_params: Request<{ params: SlashingParam }>;
   slashing_signing_info: Request<PaginatedSigningInfo>;
 
   gov_params_voting: Request<GovParams>;
@@ -124,7 +125,7 @@ export interface RequestRegistry extends AbstractRegistry {
   base_tendermint_validatorsets_latest: Request<PaginatedTendermintValidator>;
   base_tendermint_validatorsets_height: Request<PaginatedTendermintValidator>;
 
-  params: Request<{param: any}>;
+  params: Request<{ param: any }>;
 
   tx_txs: Request<PaginatedTxs>;
   tx_txs_block: Request<Tx>;
@@ -151,9 +152,22 @@ export interface RequestRegistry extends AbstractRegistry {
   ibc_core_connection_connections: Request<PaginatedIBCConnections>;
   ibc_core_connection_connections_connection_id: Request<ConnectionWithProof>;
   ibc_core_connection_connections_connection_id_client_state: Request<ClientStateWithProof>;
-  interchain_security_ccv_provider_validator_consumer_addr: Request<{consumer_address: string}>
-  interchain_security_provider_opted_in_validators: Request<{validators_provider_addresses: string[]}>
-  interchain_security_consumer_validators: Request<{validators: {provider_address: string, consumer_key: {ed25519: string}, power: string}[]}>
+  interchain_security_ccv_provider_validator_consumer_addr: Request<{
+    consumer_address: string;
+  }>;
+  interchain_security_provider_opted_in_validators: Request<{
+    validators_provider_addresses: string[];
+  }>;
+  interchain_security_consumer_validators: Request<{
+    validators: {
+      provider_address: string;
+      consumer_key: { ed25519: string };
+      power: string;
+    }[];
+  }>;
+
+  // hippo RPC
+  block_by_height: Request<{ result: BlocksByHeight }>;
 }
 
 export function adapter<T>(source: any): Promise<T> {
@@ -176,16 +190,20 @@ export const VERSION_REGISTRY: ApiProfileRegistry = {};
 // ChainName Profile Registory
 export const NAME_REGISTRY: ApiProfileRegistry = {};
 
-export function registryVersionProfile(version: string, requests: RequestRegistry) {
-  VERSION_REGISTRY[version] = requests
+export function registryVersionProfile(
+  version: string,
+  requests: RequestRegistry
+) {
+  VERSION_REGISTRY[version] = requests;
 }
 
-export function registryChainProfile(version: string, requests: RequestRegistry) {
-  NAME_REGISTRY[version] = requests
+export function registryChainProfile(
+  version: string,
+  requests: RequestRegistry
+) {
+  NAME_REGISTRY[version] = requests;
 }
-export function findApiProfileByChain(
-  name: string,
-): RequestRegistry {
+export function findApiProfileByChain(name: string): RequestRegistry {
   const url = NAME_REGISTRY[name];
   // if (!url) {
   //   throw new Error(`Unsupported version or name: ${name}`);
@@ -194,12 +212,12 @@ export function findApiProfileByChain(
 }
 
 export function findApiProfileBySDKVersion(
-  version: string,
+  version: string
 ): RequestRegistry | undefined {
   let closestVersion: string | null = null;
-  const chain_version = version.match(/(\d+\.\d+\.?\d*)/g) || [""];
+  const chain_version = version.match(/(\d+\.\d+\.?\d*)/g) || [''];
   for (const k in VERSION_REGISTRY) {
-    const key = k.replace('v', "")
+    const key = k.replace('v', '');
     if (semver.lte(key, chain_version[0])) {
       if (!closestVersion || semver.gt(key, closestVersion)) {
         closestVersion = k;

--- a/src/libs/client.ts
+++ b/src/libs/client.ts
@@ -368,4 +368,12 @@ export class CosmosRestClient extends BaseRestClient<RequestRegistry> {
   async getInterchainSecurityConsumerValidators(chain_id: string) {
     return this.request(this.registry.interchain_security_consumer_validators, {chain_id});
   }
+
+
+
+  //RPC
+  async getBlocksByHeight(minHeight: string | number, maxHeight: string | number) {
+    return this.request(this.registry.block_by_height, { minHeight, maxHeight });
+  }
+
 }

--- a/src/modules/[chain]/block/index.vue
+++ b/src/modules/[chain]/block/index.vue
@@ -3,6 +3,7 @@ import { computed, ref } from '@vue/reactivity';
 import { useBaseStore, useFormatter } from '@/stores';
 import TxsInBlocksChart from '@/components/charts/TxsInBlocksChart.vue';
 import { watch } from 'vue';
+import PaginationBar from '@/components/PaginationBar.vue';
 
 const props = defineProps(['chain']);
 
@@ -16,18 +17,25 @@ const list = computed(() => {
   return base.latestBlocks.block_metas || [];
 });
 
+const pageSize = 20;
+const onPageChange = (page: number) => {
+  base.fetchBlocks(
+    Number(base.latest.block.header.height) - page * pageSize,
+    Number(base.latest.block.header.height) - (page - 1) * pageSize
+  );
+};
+
 watch(
   () => base.latest,
   (newLatest) => {
     if (newLatest && list.value.length === 0) {
       base.fetchBlocks(
-        Number(newLatest.block.header.height) - 25,
+        Number(newLatest.block.header.height) - pageSize,
         newLatest.block.header.height
       );
     }
-  },
+  }
 );
-
 </script>
 <template>
   <div>
@@ -79,8 +87,11 @@ watch(
             </span>
           </div>
         </RouterLink>
-        <!-- TODO pagination -->
-        <!-- <PaginationBar :total="store?.proposals[tab]?.pagination?.total" :limit="pageRequest.limit" :callback="page" /> -->
+        <PaginationBar
+          :total="base.latest.block?.header.height"
+          :limit="pageSize"
+          :callback="onPageChange"
+        />
       </div>
     </div>
   </div>

--- a/src/modules/[chain]/block/index.vue
+++ b/src/modules/[chain]/block/index.vue
@@ -2,57 +2,88 @@
 import { computed, ref } from '@vue/reactivity';
 import { useBaseStore, useFormatter } from '@/stores';
 import TxsInBlocksChart from '@/components/charts/TxsInBlocksChart.vue';
+import { watch } from 'vue';
 
 const props = defineProps(['chain']);
 
 const tab = ref('blocks');
 
-const base = useBaseStore()
+const base = useBaseStore();
 
 const format = useFormatter();
 
 const list = computed(() => {
-    // const recents = base.recents
-    // return recents.sort((a, b) => (Number(b.block.header.height) - Number(a.block.header.height)))
-    return base.recents
-})
+  return base.latestBlocks.block_metas || [];
+});
+
+watch(
+  () => base.latest,
+  (newLatest) => {
+    if (newLatest && list.value.length === 0) {
+      base.fetchBlocks(
+        Number(newLatest.block.header.height) - 25,
+        newLatest.block.header.height
+      );
+    }
+  },
+);
+
 </script>
 <template>
-    <div>
-        <div class="tabs tabs-boxed bg-transparent mb-4">
-            <a class="tab text-gray-400 uppercase" :class="{ 'tab-active': tab === 'blocks' }"
-                @click="tab = 'blocks'">{{ $t('block.recent') }}</a>
-            <RouterLink class="tab text-gray-400 uppercase" 
-                :to="`/${chain}/block/${Number(base.latest?.block?.header.height||0) + 10000}`"
-                >{{ $t('block.future') }}</RouterLink>
-        </div>
-
-        <div v-show="tab === 'blocks'">
-
-            <TxsInBlocksChart />
-
-            <div class="grid xl:!grid-cols-6 md:!grid-cols-4 grid-cols-1 gap-3">
-            <RouterLink v-for="item in list"
-                class="flex flex-col justify-between rounded p-4 shadow bg-base-100"
-                :to="`/${chain}/block/${item.block.header.height}`">
-                <div class="flex justify-between">
-                    <h3 class="text-md font-bold sm:!text-lg">
-                        {{ item.block.header.height }}
-                    </h3>
-                    <span class="rounded text-xs whitespace-nowrap font-medium text-green-600">
-                        {{ format.toDay(item.block?.header?.time, 'from') }}
-                    </span>
-                </div>
-                <div class="flex justify-between tooltip" data-tip="Block Proposor">
-                    <div class="mt-2 hidden text-sm sm:!block truncate">
-                        <span>{{ format.validator(item.block?.header?.proposer_address) }}</span>
-                    </div>
-                    <span class="text-right mt-1 whitespace-nowrap"> {{ item.block?.data?.txs.length }} txs </span>
-                </div>
-            </RouterLink>
-            </div>
-        </div>
+  <div>
+    <div class="tabs tabs-boxed bg-transparent mb-4">
+      <a
+        class="tab text-gray-400 uppercase"
+        :class="{ 'tab-active': tab === 'blocks' }"
+        @click="tab = 'blocks'"
+        >{{ $t('block.recent') }}</a
+      >
+      <RouterLink
+        class="tab text-gray-400 uppercase"
+        :to="`/${chain}/block/${
+          Number(base.latest?.block?.header.height || 0) + 10000
+        }`"
+        >{{ $t('block.future') }}</RouterLink
+      >
     </div>
+
+    <div v-show="tab === 'blocks'">
+      <TxsInBlocksChart />
+
+      <div class="grid grid-cols-1 gap-3">
+        <RouterLink
+          v-for="item in list"
+          class="flex flex-col justify-between rounded p-4 shadow bg-base-100"
+          :to="`/${chain}/block/${item.header.height}`"
+        >
+          <div class="flex justify-between">
+            <h3 class="text-md font-bold sm:!text-lg">
+              {{ item.header.height }}
+            </h3>
+            <div class="flex justify-between tooltip" data-tip="Block Proposor">
+              <div class="hidden text-md sm:!block truncate">
+                <h3 class="text-md font-bold sm:!text-lg">
+                  {{ format.validatorFromHex(item.header?.proposer_address) }}
+                </h3>
+              </div>
+            </div>
+            <span
+              class="text-right whitespace-nowrap font-normal text-md sm:!text-lg"
+            >
+              {{ item.num_txs }} txs
+            </span>
+            <span
+              class="rounded whitespace-nowrap font-normal text-green-600 text-md sm:!text-lg"
+            >
+              {{ format.toDay(item.header?.time, 'from') }}
+            </span>
+          </div>
+        </RouterLink>
+        <!-- TODO pagination -->
+        <!-- <PaginationBar :total="store?.proposals[tab]?.pagination?.total" :limit="pageRequest.limit" :callback="page" /> -->
+      </div>
+    </div>
+  </div>
 </template>
 
 <route>

--- a/src/modules/[chain]/gov/[proposal_id].vue
+++ b/src/modules/[chain]/gov/[proposal_id].vue
@@ -22,7 +22,6 @@ import Countdown from '@/components/Countdown.vue';
 import PaginationBar from '@/components/PaginationBar.vue';
 import { fromBech32, toHex } from '@cosmjs/encoding';
 
-
 const props = defineProps(['proposal_id', 'chain']);
 const proposal = ref({} as GovProposal);
 const format = useFormatter();
@@ -41,35 +40,35 @@ store.fetchProposal(props.proposal_id).then((res) => {
   }
   proposal.value = proposalDetail;
   // load origin params if the proposal is param change
-  if(proposalDetail.content?.changes) {
-    proposalDetail.content?.changes.forEach((item) => {  
-        chainStore.rpc.getParams(item.subspace, item.key).then((res) => {
-          if(proposal.value.content && res.param) {
-            if(proposal.value.content.current){
-              proposal.value.content.current.push(res.param);
-            } else {
-              proposal.value.content.current = [res.param];
-            };
+  if (proposalDetail.content?.changes) {
+    proposalDetail.content?.changes.forEach((item) => {
+      chainStore.rpc.getParams(item.subspace, item.key).then((res) => {
+        if (proposal.value.content && res.param) {
+          if (proposal.value.content.current) {
+            proposal.value.content.current.push(res.param);
+          } else {
+            proposal.value.content.current = [res.param];
           }
-        })
-    })
+        }
+      });
+    });
   }
 
   const msgType = proposalDetail.content?.['@type'] || '';
-  if(msgType.endsWith('MsgUpdateParams')) {
-    if(msgType.indexOf('staking') > -1) {
+  if (msgType.endsWith('MsgUpdateParams')) {
+    if (msgType.indexOf('staking') > -1) {
       chainStore.rpc.getStakingParams().then((res) => {
         addCurrentParams(res);
       });
-    } else if(msgType.indexOf('gov') > -1) {
+    } else if (msgType.indexOf('gov') > -1) {
       chainStore.rpc.getGovParamsVoting().then((res) => {
         addCurrentParams(res);
       });
-    } else if(msgType.indexOf('distribution') > -1) {
+    } else if (msgType.indexOf('distribution') > -1) {
       chainStore.rpc.getDistributionParams().then((res) => {
         addCurrentParams(res);
       });
-    } else if(msgType.indexOf('slashing') > -1) {
+    } else if (msgType.indexOf('slashing') > -1) {
       chainStore.rpc.getSlashingParams().then((res) => {
         addCurrentParams(res);
       });
@@ -78,7 +77,7 @@ store.fetchProposal(props.proposal_id).then((res) => {
 });
 
 function addCurrentParams(res: any) {
-  if(proposal.value.content && res.params) {
+  if (proposal.value.content && res.params) {
     proposal.value.content.params = [proposal.value.content?.params];
     proposal.value.content.current = [res.params];
   }
@@ -128,7 +127,9 @@ const upgradeCountdown = computed((): number => {
   if (height > 0) {
     const base = useBaseStore();
     const current = Number(base.latest?.block?.header?.height || 0);
-    return (height - current) * Number((base.blocktime / 1000).toFixed()) * 1000;
+    return (
+      (height - current) * Number((base.blocktime / 1000).toFixed()) * 1000
+    );
   }
   const now = new Date();
   const end = new Date(proposal.value.content?.plan?.time || '');
@@ -186,13 +187,43 @@ const abstain = computed(() => {
   }
   return 0;
 });
+
+const formatHippo = (raw: string) => {
+  return format.tokenAmountNumber({ amount: raw, denom: 'ahp' }).toFixed(2);
+};
+
 const processList = computed(() => {
   return [
-    { name: 'Turnout', value: turnout.value, class: 'bg-info' },
-    { name: 'Yes', value: yes.value, class: 'bg-success' },
-    { name: 'No', value: no.value, class: 'bg-error' },
-    { name: 'No With Veto', value: veto.value, class: 'bg-red-800' },
-    { name: 'Abstain', value: abstain.value, class: 'bg-warning' },
+    {
+      name: 'Turnout',
+      value: turnout.value,
+      class: 'bg-info',
+      raw: formatHippo(total.value.toString()),
+    },
+    {
+      name: 'Yes',
+      value: yes.value,
+      class: 'bg-success',
+      raw: formatHippo(proposal.value?.final_tally_result?.yes || '0'),
+    },
+    {
+      name: 'No',
+      value: no.value,
+      class: 'bg-error',
+      raw: formatHippo(proposal.value?.final_tally_result?.no || '0'),
+    },
+    {
+      name: 'No With Veto',
+      value: veto.value,
+      class: 'bg-red-800',
+      raw: formatHippo(proposal.value?.final_tally_result?.no_with_veto || '0'),
+    },
+    {
+      name: 'Abstain',
+      value: abstain.value,
+      class: 'bg-warning',
+      raw: formatHippo(proposal.value?.final_tally_result?.abstain || '0'),
+    },
   ];
 });
 
@@ -213,22 +244,32 @@ function pageload(p: number) {
   });
 }
 
-function metaItem(metadata: string|undefined): { title: string; summary: string } {
+function metaItem(metadata: string | undefined): {
+  title: string;
+  summary: string;
+} {
   if (!metadata) {
-    return { title: '', summary: '' }
+    return { title: '', summary: '' };
   } else if (metadata.startsWith('{') && metadata.endsWith('}')) {
-    return JSON.parse(metadata)
+    return JSON.parse(metadata);
   }
-  return { title: metadata, summary: '' }
+  return { title: metadata, summary: '' };
 }
 </script>
 
 <template>
   <div>
     <div class="bg-base-100 px-4 pt-3 pb-4 rounded mb-4 shadow">
-      <h2 class="card-title flex flex-col md:!justify-between md:!flex-row mb-2">
+      <h2
+        class="card-title flex flex-col md:!justify-between md:!flex-row mb-2"
+      >
         <p class="truncate w-full">
-          {{ proposal_id }}. {{ proposal.title || proposal.content?.title || metaItem(proposal?.metadata)?.title  }}
+          {{ proposal_id }}.
+          {{
+            proposal.title ||
+            proposal.content?.title ||
+            metaItem(proposal?.metadata)?.title
+          }}
         </p>
         <div
           class="badge badge-ghost"
@@ -246,9 +287,18 @@ function metaItem(metadata: string|undefined): { title: string; summary: string 
       <div class="">
         <ObjectElement :value="proposal.content" />
       </div>
-      <div v-if="proposal.summary && !proposal.content?.description || metaItem(proposal?.metadata)?.summary ">
+      <div
+        v-if="
+          (proposal.summary && !proposal.content?.description) ||
+          metaItem(proposal?.metadata)?.summary
+        "
+      >
         <MdEditor
-          :model-value="format.multiLine(proposal.summary || metaItem(proposal?.metadata)?.summary)"
+          :model-value="
+            format.multiLine(
+              proposal.summary || metaItem(proposal?.metadata)?.summary
+            )
+          "
           previewOnly
           class="md-editor-recover"
         ></MdEditor>
@@ -278,6 +328,9 @@ function metaItem(metadata: string|undefined): { title: string; summary: string 
               class="absolute inset-x-0 inset-y-0 text-center text-sm text-[#666] dark:text-[#eee] flex items-center justify-center"
             >
               {{ item.value }}
+              <span v-if="item.value !== '-' && item.value !== 'NaN%'" class="ml-1">
+                {{ `(${item.raw}HP)` }}
+              </span>
             </p>
           </div>
         </div>
@@ -304,7 +357,8 @@ function metaItem(metadata: string|undefined): { title: string; summary: string 
           <div class="flex items-center mb-4 mt-2">
             <div class="w-2 h-2 rounded-full bg-error mr-3"></div>
             <div class="text-base flex-1 text-main">
-              {{ $t('gov.submit_at') }}: {{ format.toDay(proposal.submit_time) }}
+              {{ $t('gov.submit_at') }}:
+              {{ format.toDay(proposal.submit_time) }}
             </div>
             <div class="text-sm">{{ shortTime(proposal.submit_time) }}</div>
           </div>
@@ -334,7 +388,8 @@ function metaItem(metadata: string|undefined): { title: string; summary: string 
             <div class="flex items-center">
               <div class="w-2 h-2 rounded-full bg-yes mr-3"></div>
               <div class="text-base flex-1 text-main">
-                {{ $t('gov.vote_start_from') }} {{ format.toDay(proposal.voting_start_time) }}
+                {{ $t('gov.vote_start_from') }}
+                {{ format.toDay(proposal.voting_start_time) }}
               </div>
               <div class="text-sm">
                 {{ shortTime(proposal.voting_start_time) }}
@@ -348,14 +403,16 @@ function metaItem(metadata: string|undefined): { title: string; summary: string 
             <div class="flex items-center mb-1">
               <div class="w-2 h-2 rounded-full bg-success mr-3"></div>
               <div class="text-base flex-1 text-main">
-                {{ $t('gov.vote_end') }} {{ format.toDay(proposal.voting_end_time) }}
+                {{ $t('gov.vote_end') }}
+                {{ format.toDay(proposal.voting_end_time) }}
               </div>
               <div class="text-sm">
                 {{ shortTime(proposal.voting_end_time) }}
               </div>
             </div>
             <div class="pl-5 text-sm">
-              {{ $t('gov.current_status') }}: {{ $t(`gov.proposal_statuses.${proposal.status}`) }}
+              {{ $t('gov.current_status') }}:
+              {{ $t(`gov.proposal_statuses.${proposal.status}`) }}
             </div>
           </div>
 
@@ -405,11 +462,18 @@ function metaItem(metadata: string|undefined): { title: string; summary: string 
               >
                 {{ String(item.option).replace('VOTE_OPTION_', '') }}
               </td>
-              <td
-                v-if="item.options"
-                class="py-2 text-sm"
-              >
-                {{ item.options.map(x => `${x.option.replace('VOTE_OPTION_', '')}:${format.percent(x.weight)}`).join(', ') }}
+              <td v-if="item.options" class="py-2 text-sm">
+                {{
+                  item.options
+                    .map(
+                      (x) =>
+                        `${x.option.replace(
+                          'VOTE_OPTION_',
+                          ''
+                        )}:${format.percent(x.weight)}`
+                    )
+                    .join(', ')
+                }}
               </td>
             </tr>
           </tbody>

--- a/src/modules/[chain]/gov/index.vue
+++ b/src/modules/[chain]/gov/index.vue
@@ -5,42 +5,66 @@ import { ref, onMounted } from 'vue';
 import PaginationBar from '@/components/PaginationBar.vue';
 import { PageRequest } from '@/types';
 
-const tab = ref('2');
+const tab = ref('0');
 const store = useGovStore();
-const pageRequest = ref(new PageRequest())
+const pageRequest = ref(new PageRequest());
 
 onMounted(() => {
-    store.fetchProposals('2').then((x) => {
-        if (x?.proposals?.length === 0) {
-            tab.value = '3';
-            store.fetchProposals('3');
-        }
-        store.fetchProposals('3');
-        store.fetchProposals('4');
-    });
+  store.fetchProposals('0').then((x) => {
+    if (x?.proposals?.length === 0) {
+      return;
+    }
+    store.fetchProposals('2');
+    store.fetchProposals('3');
+    store.fetchProposals('4');
+  });
 });
 
-const changeTab = (val: '2' | '3' | '4') => {
-    tab.value = val;
+const changeTab = (val: '0' | '2' | '3' | '4') => {
+  tab.value = val;
 };
 
 function page(p: number) {
-    pageRequest.value.setPage(p)
-    store.fetchProposals(tab.value, pageRequest.value)
+  pageRequest.value.setPage(p);
+  store.fetchProposals(tab.value, pageRequest.value);
 }
 
 </script>
 <template>
-    <div>
-        <div class="tabs tabs-boxed bg-transparent mb-4 text-center">
-            <a class="tab text-gray-400 uppercase" :class="{ 'tab-active': tab === '2' }" @click="changeTab('2')">{{ $t('gov.voting') }}</a>
-            <a class="tab text-gray-400 uppercase" :class="{ 'tab-active': tab === '3' }" @click="changeTab('3')">{{ $t('gov.passed') }}</a>
-            <a class="tab text-gray-400 uppercase" :class="{ 'tab-active': tab === '4' }"
-                @click="changeTab('4')">{{ $t('gov.rejected') }}</a>
-        </div>
-        <ProposalListItem :proposals="store?.proposals[tab]" />
-        <PaginationBar :total="store?.proposals[tab]?.pagination?.total" :limit="pageRequest.limit" :callback="page" />
+  <div>
+    <div class="tabs tabs-boxed bg-transparent mb-4 text-center">
+      <a
+        class="tab text-gray-400 uppercase"
+        :class="{ 'tab-active': tab === '0' }"
+        @click="changeTab('0')"
+        >ALL</a
+      >
+      <a
+        class="tab text-gray-400 uppercase"
+        :class="{ 'tab-active': tab === '2' }"
+        @click="changeTab('2')"
+        >{{ $t('gov.voting') }}</a
+      >
+      <a
+        class="tab text-gray-400 uppercase"
+        :class="{ 'tab-active': tab === '3' }"
+        @click="changeTab('3')"
+        >{{ $t('gov.passed') }}</a
+      >
+      <a
+        class="tab text-gray-400 uppercase"
+        :class="{ 'tab-active': tab === '4' }"
+        @click="changeTab('4')"
+        >{{ $t('gov.rejected') }}</a
+      >
     </div>
+    <ProposalListItem :proposals="store?.proposals[tab]" />
+    <PaginationBar
+      :total="store?.proposals[tab]?.pagination?.total"
+      :limit="pageRequest.limit"
+      :callback="page"
+    />
+  </div>
 </template>
 <route>
   {

--- a/src/modules/[chain]/index.vue
+++ b/src/modules/[chain]/index.vue
@@ -257,7 +257,7 @@ const amount = computed({
       </div>
     </div>
 
-    <div class="grid grid-cols-1 gap-4 md:!grid-cols-3 lg:!grid-cols-6 mt-4">
+    <div class="grid grid-cols-1 gap-4 md:!grid-cols-4 lg:!grid-cols-7 mt-4">
       <div v-for="(item, key) in store.stats" :key="key">
         <CardStatisticsVertical v-bind="item" />
       </div>

--- a/src/modules/[chain]/indexStore.ts
+++ b/src/modules/[chain]/indexStore.ts
@@ -141,20 +141,27 @@ export const useIndexModule = defineStore('module-index', {
       return gov.proposals['2'];
     },
 
-    stats() {
-      const base = useBaseStore();
+    stakingApr(){
       const bank = useBankStore();
       const staking = useStakingStore();
       const mintStore = useMintStore();
-      const formatter = useFormatter();
       const distributionStore = useDistributionStore();
-
 
       // APR = Inflation * (Total supply / Total staked) * (1 - Community tax)
       const stakingApr =
         Number(mintStore.inflation) *
         (Number(bank.supply.amount) / Number(staking.pool.bonded_tokens)) *
         (1 - Number(distributionStore.params.community_tax));
+
+        return stakingApr;
+    },
+
+    stats() {
+      const base = useBaseStore();
+      const bank = useBankStore();
+      const staking = useStakingStore();
+      const mintStore = useMintStore();
+      const formatter = useFormatter();
 
       return [
         {
@@ -202,7 +209,7 @@ export const useIndexModule = defineStore('module-index', {
           title: 'Staking APR',
           color: 'success',
           icon: 'mdi-chart-multiple',
-          stats: formatter.formatDecimalToPercent(stakingApr.toString()),
+          stats: formatter.formatDecimalToPercent(this.stakingApr.toString()),
           change: 0,
         },
         {

--- a/src/modules/[chain]/indexStore.ts
+++ b/src/modules/[chain]/indexStore.ts
@@ -87,33 +87,33 @@ export const useIndexModule = defineStore('module-index', {
       return useBankStore();
     },
     twitter(): string {
-      if(!this.coinInfo?.links?.twitter_screen_name) return ""
+      if (!this.coinInfo?.links?.twitter_screen_name) return '';
       return `https://twitter.com/${this.coinInfo?.links.twitter_screen_name}`;
     },
     homepage(): string {
-      if(!this.coinInfo?.links?.homepage) return ""
+      if (!this.coinInfo?.links?.homepage) return '';
       const [page1, page2, page3] = this.coinInfo?.links?.homepage;
       return page1 || page2 || page3;
     },
     github(): string {
-      if(!this.coinInfo?.links?.repos_url) return ""
+      if (!this.coinInfo?.links?.repos_url) return '';
       const [page1, page2, page3] = this.coinInfo?.links?.repos_url?.github;
       return page1 || page2 || page3;
     },
     telegram(): string {
-      if(!this.coinInfo?.links?.homepage) return ""
+      if (!this.coinInfo?.links?.homepage) return '';
       return `https://t.me/${this.coinInfo?.links.telegram_channel_identifier}`;
     },
 
     priceChange(): string {
-      if(!this.coinInfo?.market_data?.price_change_percentage_24h) return ""
+      if (!this.coinInfo?.market_data?.price_change_percentage_24h) return '';
       const change =
         this.coinInfo?.market_data?.price_change_percentage_24h || 0;
       return numeral(change).format('+0.[00]');
     },
 
     priceColor(): string {
-      if(!this.coinInfo?.market_data?.price_change_percentage_24h) return ""
+      if (!this.coinInfo?.market_data?.price_change_percentage_24h) return '';
       const change =
         this.coinInfo?.market_data?.price_change_percentage_24h || 0;
       switch (true) {
@@ -126,7 +126,7 @@ export const useIndexModule = defineStore('module-index', {
       }
     },
     trustColor(): string {
-      if(!this.coinInfo?.tickers) return ""
+      if (!this.coinInfo?.tickers) return '';
       const change = this.coinInfo?.tickers[this.tickerIndex]?.trust_score;
       return change;
     },
@@ -137,8 +137,8 @@ export const useIndexModule = defineStore('module-index', {
     },
 
     proposals() {
-      const gov = useGovStore()
-      return gov.proposals['2']
+      const gov = useGovStore();
+      return gov.proposals['2'];
     },
 
     stats() {
@@ -147,6 +147,14 @@ export const useIndexModule = defineStore('module-index', {
       const staking = useStakingStore();
       const mintStore = useMintStore();
       const formatter = useFormatter();
+      const distributionStore = useDistributionStore();
+
+
+      // APR = Inflation * (Total supply / Total staked) * (1 - Community tax)
+      const stakingApr =
+        Number(mintStore.inflation) *
+        (Number(bank.supply.amount) / Number(staking.pool.bonded_tokens)) *
+        (1 - Number(distributionStore.params.community_tax));
 
       return [
         {
@@ -160,7 +168,9 @@ export const useIndexModule = defineStore('module-index', {
           title: 'Validators',
           color: 'error',
           icon: 'mdi-human-queue',
-          stats: String(base?.latest?.block?.last_commit?.signatures.length || 0),
+          stats: String(
+            base?.latest?.block?.last_commit?.signatures.length || 0
+          ),
           change: 0,
         },
         {
@@ -189,6 +199,13 @@ export const useIndexModule = defineStore('module-index', {
           change: 0,
         },
         {
+          title: 'Staking APR',
+          color: 'success',
+          icon: 'mdi-chart-multiple',
+          stats: formatter.formatDecimalToPercent(stakingApr.toString()),
+          change: 0,
+        },
+        {
           title: 'Community Pool',
           color: 'primary',
           icon: 'mdi-bank',
@@ -207,8 +224,8 @@ export const useIndexModule = defineStore('module-index', {
       this.tickerIndex = 0;
       // @ts-ignore
       const [firstAsset] = this.blockchain?.assets || [];
-      return firstAsset.coingecko_id
-    }
+      return firstAsset.coingecko_id;
+    },
   },
   actions: {
     async loadDashboard() {

--- a/src/modules/[chain]/staking/index.vue
+++ b/src/modules/[chain]/staking/index.vue
@@ -1,25 +1,27 @@
 <script lang="ts" setup>
 import {
-    useBaseStore,
-    useBlockchain,
-    useFormatter,
-    useMintStore,
-    useStakingStore,
-    useTxDialog,
+  useBaseStore,
+  useBlockchain,
+  useFormatter,
+  useMintStore,
+  useStakingStore,
+  useTxDialog,
 } from '@/stores';
 import { computed } from '@vue/reactivity';
 import { onMounted, ref } from 'vue';
 import { Icon } from '@iconify/vue';
 import type { Key, SlashingParam, Validator } from '@/types';
-import { formatSeconds}  from '@/libs/utils'
+import { formatSeconds } from '@/libs/utils';
 import { diff } from 'semver';
+import { useIndexModule } from '../indexStore';
 
 const staking = useStakingStore();
 const base = useBaseStore();
 const format = useFormatter();
 const dialog = useTxDialog();
 const chainStore = useBlockchain();
-const mintStore = useMintStore()
+const mintStore = useMintStore();
+const store = useIndexModule();
 
 const cache = JSON.parse(localStorage.getItem('avatars') || '{}');
 const avatars = ref(cache || {});
@@ -27,130 +29,160 @@ const latest = ref({} as Record<string, number>);
 const yesterday = ref({} as Record<string, number>);
 const tab = ref('active');
 const unbondList = ref([] as Validator[]);
-const slashing = ref({} as SlashingParam)
+const slashing = ref({} as SlashingParam);
 
 onMounted(() => {
-    staking.fetchUnbondingValdiators().then((res) => {
-        unbondList.value = res.concat(unbondList.value);
-    });
-    staking.fetchInacitveValdiators().then((res) => {
-        unbondList.value = unbondList.value.concat(res);
-    });
-    chainStore.rpc.getSlashingParams().then(res => {
-        slashing.value = res.params
-    })
+  staking.fetchUnbondingValdiators().then((res) => {
+    unbondList.value = res.concat(unbondList.value);
+  });
+  staking.fetchInacitveValdiators().then((res) => {
+    unbondList.value = unbondList.value.concat(res);
+  });
+  chainStore.rpc.getSlashingParams().then((res) => {
+    slashing.value = res.params;
+  });
 });
 
 async function fetchChange(blockWindow: number = 14400) {
-    let page = 0;
+  let page = 0;
 
-    let height = Number(base.latest?.block?.header?.height || 0);
-    if (height > blockWindow) {
-        height -= blockWindow;
-    } else {
-        height = 1;
-    }
-    // voting power in 24h ago
-    while (page < staking.validators.length && height > 0) {
-        await base.fetchValidatorByHeight(height, page).then((x) => {
-            x.validators.forEach((v) => {
-                yesterday.value[v.pub_key.key] = Number(v.voting_power);
-            });
-        });
-        page += 100;
-    }
+  let height = Number(base.latest?.block?.header?.height || 0);
+  if (height > blockWindow) {
+    height -= blockWindow;
+  } else {
+    height = 1;
+  }
+  // voting power in 24h ago
+  while (page < staking.validators.length && height > 0) {
+    await base.fetchValidatorByHeight(height, page).then((x) => {
+      x.validators.forEach((v) => {
+        yesterday.value[v.pub_key.key] = Number(v.voting_power);
+      });
+    });
+    page += 100;
+  }
 
-    page = 0;
-    // voting power for now
-    while (page < staking.validators.length) {
-        await base.fetchLatestValidators(page).then((x) => {
-            x.validators.forEach((v) => {
-                latest.value[v.pub_key.key] = Number(v.voting_power);
-            });
-        });
-        page += 100;
-    }
+  page = 0;
+  // voting power for now
+  while (page < staking.validators.length) {
+    await base.fetchLatestValidators(page).then((x) => {
+      x.validators.forEach((v) => {
+        latest.value[v.pub_key.key] = Number(v.voting_power);
+      });
+    });
+    page += 100;
+  }
 }
 
 const changes = computed(() => {
-    const changes = {} as Record<string, number>;
-    Object.keys(latest.value).forEach((k) => {
-        const l = latest.value[k] || 0;
-        const y = yesterday.value[k] || 0;
-        changes[k] = l - y;
-    });
-    return changes;
+  const changes = {} as Record<string, number>;
+  Object.keys(latest.value).forEach((k) => {
+    const l = latest.value[k] || 0;
+    const y = yesterday.value[k] || 0;
+    changes[k] = l - y;
+  });
+  return changes;
 });
 
 const change24 = (entry: { consensus_pubkey: Key; tokens: string }) => {
-    const txt = entry.consensus_pubkey.key;
-    // const n: number = latest.value[txt];
-    // const o: number = yesterday.value[txt];
-    // // console.log( txt, n, o)
-    // return n > 0 && o > 0 ? n - o : 0;
+  const txt = entry.consensus_pubkey.key;
+  // const n: number = latest.value[txt];
+  // const o: number = yesterday.value[txt];
+  // // console.log( txt, n, o)
+  // return n > 0 && o > 0 ? n - o : 0;
 
-    const latestValue = latest.value[txt];
-    if (!latestValue) {
-        return 0;
-    }
+  const latestValue = latest.value[txt];
+  if (!latestValue) {
+    return 0;
+  }
 
-    const displayTokens = format.tokenAmountNumber({
-        amount: parseInt(entry.tokens, 10).toString(),
-        denom: staking.params.bond_denom,
-    });
-    const coefficient = displayTokens / latestValue;
-    return changes.value[txt] * coefficient;
+  const displayTokens = format.tokenAmountNumber({
+    amount: parseInt(entry.tokens, 10).toString(),
+    denom: staking.params.bond_denom,
+  });
+  const coefficient = displayTokens / latestValue;
+  return changes.value[txt] * coefficient;
 };
 
 const change24Text = (entry: { consensus_pubkey: Key; tokens: string }) => {
-    if (!entry) return '';
-    const v = change24(entry);
-    return v && v !== 0 ? format.showChanges(v) : '';
+  if (!entry) return '';
+  const v = change24(entry);
+  return v && v !== 0 ? format.showChanges(v) : '';
 };
 
 const change24Color = (entry: { consensus_pubkey: Key; tokens: string }) => {
-    if (!entry) return '';
-    const v = change24(entry);
-    if (v > 0) return 'text-success';
-    if (v < 0) return 'text-error';
+  if (!entry) return '';
+  const v = change24(entry);
+  if (v > 0) return 'text-success';
+  if (v < 0) return 'text-error';
 };
 
 const calculateRank = function (position: number) {
-    let sum = 0;
-    for (let i = 0; i < position; i++) {
-        sum += Number(staking.validators[i]?.delegator_shares);
-    }
-    const percent = sum / staking.totalPower;
+  let sum = 0;
+  for (let i = 0; i < position; i++) {
+    sum += Number(staking.validators[i]?.delegator_shares);
+  }
+  const percent = sum / staking.totalPower;
 
-    switch (true) {
-        case tab.value === 'active' && percent < 0.33:
-            return 'error';
-        case tab.value === 'active' && percent < 0.67:
-            return 'warning';
-        default:
-            return 'primary';
-    }
+  switch (true) {
+    case tab.value === 'active' && percent < 0.33:
+      return 'error';
+    case tab.value === 'active' && percent < 0.67:
+      return 'warning';
+    default:
+      return 'primary';
+  }
 };
 
-function isFeatured(endpoints: string[], who?: {website?: string, moniker: string }) {
-    if(!endpoints || !who) return false
-    return endpoints.findIndex(x => who.website && who.website?.substring(0, who.website?.lastIndexOf('.')).endsWith(x) || who?.moniker?.toLowerCase().search(x.toLowerCase()) > -1) > -1
+function isFeatured(
+  endpoints: string[],
+  who?: { website?: string; moniker: string }
+) {
+  if (!endpoints || !who) return false;
+  return (
+    endpoints.findIndex(
+      (x) =>
+        (who.website &&
+          who.website
+            ?.substring(0, who.website?.lastIndexOf('.'))
+            .endsWith(x)) ||
+        who?.moniker?.toLowerCase().search(x.toLowerCase()) > -1
+    ) > -1
+  );
 }
 
 const list = computed(() => {
-    if (tab.value === 'active') {
-        return staking.validators.map((x, i) => ({v: x, rank: calculateRank(i), logo: logo(x.description.identity)}));
-    } else if (tab.value === 'featured') {
-        const endpoint = chainStore.current?.endpoints?.rest?.map(x => x.provider)
-        if(endpoint) {
-            endpoint.push('ping')
-            return staking.validators
-                .filter(x => isFeatured(endpoint, x.description))
-                .map((x, i) => ({v: x, rank: 'primary', logo: logo(x.description.identity)}));
-        }
-        return []        
+  if (tab.value === 'active') {
+    return staking.validators.map((x, i) => ({
+      v: x,
+      rank: calculateRank(i),
+      logo: logo(x.description.identity),
+    }));
+  } else if (tab.value === 'featured') {
+    const endpoint = chainStore.current?.endpoints?.rest?.map(
+      (x) => x.provider
+    );
+    if (endpoint) {
+      endpoint.push('ping');
+      return staking.validators
+        .filter((x) => isFeatured(endpoint, x.description))
+        .map((x, i) => ({
+          v: x,
+          rank: 'primary',
+          logo: logo(x.description.identity),
+        }));
     }
-    return unbondList.value.map((x, i) => ({v: x, rank: 'primary', logo: logo(x.description.identity)}));
+    return [];
+  }
+  return unbondList.value.map((x, i) => ({
+    v: x,
+    rank: 'primary',
+    logo: logo(x.description.identity),
+  }));
+});
+
+const apr = computed(() => {
+  return store.stats.find((stat) => stat.title === 'Staking APR')?.stats;
 });
 
 const fetchAvatar = (identity: string) => {
@@ -202,294 +234,343 @@ const loadAvatars = () => {
 };
 
 const logo = (identity?: string) => {
-    if (!identity || !avatars.value[identity]) return '';
-    const url = avatars.value[identity] || '';
-    return url.startsWith('http')
-        ? url
-        : `https://s3.amazonaws.com/keybase_processed_uploads/${url}`;
+  if (!identity || !avatars.value[identity]) return '';
+  const url = avatars.value[identity] || '';
+  return url.startsWith('http')
+    ? url
+    : `https://s3.amazonaws.com/keybase_processed_uploads/${url}`;
 };
 
 const loaded = ref(false);
 base.$subscribe((_, s) => {
-    if (s.recents.length >= 2 && loaded.value === false) {
-        loaded.value = true;
-        const diff_time = Date.parse(s.recents[1].block.header.time) - Date.parse(s.recents[0].block.header.time)
-        const diff_height = Number(s.recents[1].block.header.height) - Number(s.recents[0].block.header.height)
-        const block_window = Number(Number(86400 * 1000 * diff_height / diff_time).toFixed(0))
-        fetchChange(block_window);
-    }
+  if (s.recents.length >= 2 && loaded.value === false) {
+    loaded.value = true;
+    const diff_time =
+      Date.parse(s.recents[1].block.header.time) -
+      Date.parse(s.recents[0].block.header.time);
+    const diff_height =
+      Number(s.recents[1].block.header.height) -
+      Number(s.recents[0].block.header.height);
+    const block_window = Number(
+      Number((86400 * 1000 * diff_height) / diff_time).toFixed(0)
+    );
+    fetchChange(block_window);
+  }
 });
 
 loadAvatars();
 </script>
 <template>
-<div>
-    <div class="bg-base-100 rounded-lg grid sm:grid-cols-1 md:grid-cols-4 p-4" >    
-        <div class="flex">
-            <span>
-                <div class="relative w-9 h-9 rounded overflow-hidden flex items-center justify-center mr-2">
-                    <Icon class="text-success" icon="mdi:trending-up" size="32" />
-                    <div class="absolute top-0 left-0 bottom-0 right-0 opacity-20 bg-success"></div>
-                </div>
-            </span>
-            <span>
-                <div class="font-bold">{{ format.percent(mintStore.inflation) }}</div>
-                <div class="text-xs">{{ $t('staking.inflation') }}</div>
-            </span>
-        </div>
-        <div class="flex">
-            <span>
-                <div class="relative w-9 h-9 rounded overflow-hidden flex items-center justify-center mr-2">
-                    <Icon class="text-primary" icon="mdi:lock-open-outline" size="32" />
-                    <div class="absolute top-0 left-0 bottom-0 right-0 opacity-20 bg-primary"></div>
-                </div>
-            </span>
-            <span>
-                <div class="font-bold">{{ formatSeconds(staking.params?.unbonding_time) }}</div>
-                <div class="text-xs">{{ $t('staking.unbonding_time') }}</div>
-            </span>
-        </div> 
-        <div class="flex">
-            <span>
-                <div class="relative w-9 h-9 rounded overflow-hidden flex items-center justify-center mr-2">
-                    <Icon class="text-error" icon="mdi:alert-octagon-outline" size="32" />
-                    <div class="absolute top-0 left-0 bottom-0 right-0 opacity-20 bg-error"></div>
-                </div>
-            </span>
-            <span>
-            <div class="font-bold">{{ format.percent(slashing.slash_fraction_double_sign) }}</div>
-            <div class="text-xs">{{ $t('staking.double_sign_slashing') }}</div>
-            </span>
-        </div> 
-        <div class="flex">
-            <span>
-                <div class="relative w-9 h-9 rounded overflow-hidden flex items-center justify-center mr-2">
-                    <Icon class="text-error" icon="mdi:pause" size="32" />
-                    <div class="absolute top-0 left-0 bottom-0 right-0 opacity-20 bg-error"></div>
-                </div>
-            </span>
-            <span>
-            <div class="font-bold">{{ format.percent(slashing.slash_fraction_downtime) }}</div>
-            <div class="text-xs">{{ $t('staking.downtime_slashing') }}</div>
-            </span>
-        </div>  
+  <div>
+    <div class="bg-base-100 rounded-lg grid sm:grid-cols-1 md:grid-cols-5 p-4">
+      <div class="flex">
+        <span>
+          <div
+            class="relative w-9 h-9 rounded overflow-hidden flex items-center justify-center mr-2"
+          >
+            <Icon class="text-success" icon="mdi:trending-up" size="32" />
+            <div
+              class="absolute top-0 left-0 bottom-0 right-0 opacity-20 bg-success"
+            ></div>
+          </div>
+        </span>
+        <span>
+          <div class="font-bold">{{ format.percent(mintStore.inflation) }}</div>
+          <div class="text-xs">{{ $t('staking.inflation') }}</div>
+        </span>
+      </div>
+      <div class="flex">
+        <span>
+          <div
+            class="relative w-9 h-9 rounded overflow-hidden flex items-center justify-center mr-2"
+          >
+            <Icon class="text-primary" icon="mdi:lock-open-outline" size="32" />
+            <div
+              class="absolute top-0 left-0 bottom-0 right-0 opacity-20 bg-primary"
+            ></div>
+          </div>
+        </span>
+        <span>
+          <div class="font-bold">
+            {{ formatSeconds(staking.params?.unbonding_time) }}
+          </div>
+          <div class="text-xs">{{ $t('staking.unbonding_time') }}</div>
+        </span>
+      </div>
+      <div class="flex">
+        <span>
+          <div
+            class="relative w-9 h-9 rounded overflow-hidden flex items-center justify-center mr-2"
+          >
+            <Icon
+              class="text-error"
+              icon="mdi:alert-octagon-outline"
+              size="32"
+            />
+            <div
+              class="absolute top-0 left-0 bottom-0 right-0 opacity-20 bg-error"
+            ></div>
+          </div>
+        </span>
+        <span>
+          <div class="font-bold">
+            {{ format.percent(slashing.slash_fraction_double_sign) }}
+          </div>
+          <div class="text-xs">{{ $t('staking.double_sign_slashing') }}</div>
+        </span>
+      </div>
+      <div class="flex">
+        <span>
+          <div
+            class="relative w-9 h-9 rounded overflow-hidden flex items-center justify-center mr-2"
+          >
+            <Icon class="text-error" icon="mdi:pause" size="32" />
+            <div
+              class="absolute top-0 left-0 bottom-0 right-0 opacity-20 bg-error"
+            ></div>
+          </div>
+        </span>
+        <span>
+          <div class="font-bold">
+            {{ format.percent(slashing.slash_fraction_downtime) }}
+          </div>
+          <div class="text-xs">{{ $t('staking.downtime_slashing') }}</div>
+        </span>
+      </div>
+      <div class="flex">
+        <span>
+          <div
+            class="relative w-9 h-9 rounded overflow-hidden flex items-center justify-center mr-2"
+          >
+            <Icon class="text-success" icon="mdi:trending-up" size="32" />
+            <div
+              class="absolute top-0 left-0 bottom-0 right-0 opacity-20 bg-success"
+            ></div>
+          </div>
+        </span>
+        <span>
+          <div class="font-bold">
+            {{ apr }}
+          </div>
+          <div class="text-xs">Staking APR</div>
+        </span>
+      </div>
     </div>
 
     <div>
-        <div class="flex items-center justify-between py-1">
-            <div class="tabs tabs-boxed bg-transparent">
-                <a
-                    class="tab text-gray-400"
-                    :class="{ 'tab-active': tab === 'featured' }"
-                    @click="tab = 'featured'"
-                    >{{ $t('staking.popular') }}</a
-                >
-                <a
-                    class="tab text-gray-400"
-                    :class="{ 'tab-active': tab === 'active' }"
-                    @click="tab = 'active'"
-                    >{{ $t('staking.active') }}</a
-                >
-                <a
-                    class="tab text-gray-400"
-                    :class="{ 'tab-active': tab === 'inactive' }"
-                    @click="tab = 'inactive'"
-                    >{{ $t('staking.inactive') }}</a
-                >
-            </div>
-
-            <div class="text-lg font-semibold">
-                {{ list.length }}/{{ staking.params.max_validators }}
-            </div>
+      <div class="flex items-center justify-between py-1">
+        <div class="tabs tabs-boxed bg-transparent">
+          <a
+            class="tab text-gray-400"
+            :class="{ 'tab-active': tab === 'featured' }"
+            @click="tab = 'featured'"
+            >{{ $t('staking.popular') }}</a
+          >
+          <a
+            class="tab text-gray-400"
+            :class="{ 'tab-active': tab === 'active' }"
+            @click="tab = 'active'"
+            >{{ $t('staking.active') }}</a
+          >
+          <a
+            class="tab text-gray-400"
+            :class="{ 'tab-active': tab === 'inactive' }"
+            @click="tab = 'inactive'"
+            >{{ $t('staking.inactive') }}</a
+          >
         </div>
 
-        <div class="bg-base-100 px-4 pt-3 pb-4 rounded shadow">
-            <div class="overflow-x-auto">
-                <table class="table staking-table w-full">
-                    <thead class=" bg-base-200">
-                        <tr>
-                            <th
-                                scope="col"
-                                class="uppercase"
-                                style="width: 3rem; position: relative"
-                            >
-                            {{ $t('staking.rank') }}    
-                            </th>
-                            <th scope="col" class="uppercase">{{ $t('staking.validator') }}</th>
-                            <th scope="col" class="text-right uppercase">{{ $t('staking.voting_power') }}</th>
-                            <th scope="col" class="text-right uppercase">{{ $t('staking.24h_changes') }}</th>
-                            <th scope="col" class="text-right uppercase">{{ $t('staking.commission') }}</th>
-                            <th scope="col" class="text-center uppercase">{{ $t('staking.actions') }}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr
-                            v-for="({v, rank, logo}, i) in list"
-                            :key="v.operator_address"
-                            class="hover:bg-gray-100 dark:hover:bg-[#384059]"
+        <div class="text-lg font-semibold">
+          {{ list.length }}/{{ staking.params.max_validators }}
+        </div>
+      </div>
+
+      <div class="bg-base-100 px-4 pt-3 pb-4 rounded shadow">
+        <div class="overflow-x-auto">
+          <table class="table staking-table w-full">
+            <thead class="bg-base-200">
+              <tr>
+                <th
+                  scope="col"
+                  class="uppercase"
+                  style="width: 3rem; position: relative"
+                >
+                  {{ $t('staking.rank') }}
+                </th>
+                <th scope="col" class="uppercase">
+                  {{ $t('staking.validator') }}
+                </th>
+                <th scope="col" class="text-right uppercase">
+                  {{ $t('staking.voting_power') }}
+                </th>
+                <th scope="col" class="text-right uppercase">
+                  {{ $t('staking.24h_changes') }}
+                </th>
+                <th scope="col" class="text-right uppercase">
+                  {{ $t('staking.commission') }}
+                </th>
+                <th scope="col" class="text-center uppercase">
+                  {{ $t('staking.actions') }}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="({ v, rank, logo }, i) in list"
+                :key="v.operator_address"
+                class="hover:bg-gray-100 dark:hover:bg-[#384059]"
+              >
+                <!-- 👉 rank -->
+                <td>
+                  <div
+                    class="text-xs truncate relative px-2 py-1 rounded-full w-fit"
+                    :class="`text-${rank}`"
+                  >
+                    <span
+                      class="inset-x-0 inset-y-0 opacity-10 absolute"
+                      :class="`bg-${rank}`"
+                    ></span>
+                    {{ i + 1 }}
+                  </div>
+                </td>
+                <!-- 👉 Validator -->
+                <td>
+                  <div
+                    class="flex items-center overflow-hidden"
+                    style="max-width: 300px"
+                  >
+                    <div class="avatar mr-4 relative w-8 h-8 rounded-full">
+                      <div
+                        class="w-8 h-8 rounded-full bg-gray-400 absolute opacity-10"
+                      ></div>
+                      <div class="w-8 h-8 rounded-full">
+                        <img
+                          v-if="logo"
+                          :src="logo"
+                          class="object-contain"
+                          @error="
+                            (e) => {
+                              const identity = v.description?.identity;
+                              if (identity) loadAvatar(identity);
+                            }
+                          "
+                        />
+                        <Icon
+                          v-else
+                          class="text-3xl"
+                          :icon="`mdi-help-circle-outline`"
+                        />
+                      </div>
+                    </div>
+
+                    <div class="flex flex-col">
+                      <span
+                        class="text-sm text-primary dark:invert whitespace-nowrap overflow-hidden"
+                      >
+                        <RouterLink
+                          :to="{
+                            name: 'chain-staking-validator',
+                            params: {
+                              validator: v.operator_address,
+                            },
+                          }"
+                          class="font-weight-medium"
                         >
-                            <!-- 👉 rank -->
-                            <td>
-                                <div
-                                    class="text-xs truncate relative px-2 py-1 rounded-full w-fit"
-                                    :class="`text-${rank}`"
-                                >
-                                    <span
-                                        class="inset-x-0 inset-y-0 opacity-10 absolute"
-                                        :class="`bg-${rank}`"
-                                    ></span>
-                                    {{ i + 1 }}
-                                </div>
-                            </td>
-                            <!-- 👉 Validator -->
-                            <td>
-                                <div
-                                    class="flex items-center overflow-hidden"
-                                    style="max-width: 300px"
-                                >
-                                    <div
-                                        class="avatar mr-4 relative w-8 h-8 rounded-full"
-                                    >
-                                        <div
-                                            class="w-8 h-8 rounded-full bg-gray-400 absolute opacity-10"
-                                        ></div>
-                                        <div class="w-8 h-8 rounded-full">
-                                            <img
-                                                v-if="logo"
-                                                :src="logo"
-                                                class="object-contain"
-                                                @error="
-                                                    (e) => {
-                                                        const identity = v.description?.identity;
-                                                        if (identity) loadAvatar(identity);
-                                                    }
-                                                "
-                                            />
-                                            <Icon
-                                                v-else
-                                                class="text-3xl"
-                                                :icon="`mdi-help-circle-outline`"
-                                            />
-                                            
-                                        </div>
-                                    </div>
+                          {{ v.description?.moniker }}
+                        </RouterLink>
+                      </span>
+                      <span class="text-xs">{{
+                        v.description?.website || v.description?.identity || '-'
+                      }}</span>
+                    </div>
+                  </div>
+                </td>
 
-                                    <div class="flex flex-col">
-                                        <span class="text-sm text-primary dark:invert whitespace-nowrap overflow-hidden">
-                                            <RouterLink
-                                                :to="{
-                                                    name: 'chain-staking-validator',
-                                                    params: {
-                                                        validator:
-                                                            v.operator_address,
-                                                    },
-                                                }"
-                                                class="font-weight-medium"
-                                            >
-                                                {{ v.description?.moniker }}
-                                            </RouterLink>
-                                        </span>
-                                        <span class="text-xs">{{
-                                            v.description?.website ||
-                                            v.description?.identity ||
-                                            '-'
-                                        }}</span>
-                                    </div>
-                                </div>
-                            </td>
-
-                            <!-- 👉 Voting Power -->
-                            <td class="text-right">
-                                <div class="flex flex-col">
-                                    <h6 class="text-sm font-weight-medium whitespace-nowrap ">
-                                        {{
-                                            format.formatToken(
-                                                {
-                                                    amount: parseInt(
-                                                        v.tokens
-                                                    ).toString(),
-                                                    denom: staking.params
-                                                        .bond_denom,
-                                                },
-                                                true,
-                                                '0,0'
-                                            )
-                                        }}
-                                    </h6>
-                                    <span class="text-xs">{{
-                                        format.calculatePercent(
-                                            v.delegator_shares,
-                                            staking.totalPower
-                                        )
-                                    }}</span>
-                                </div>
-                            </td>
-                            <!-- 👉 24h Changes -->
-                            <td
-                                class="text-right text-xs"
-                                :class="change24Color(v)"
-                            >
-                                {{ change24Text(v) }}
-                            </td>
-                            <!-- 👉 commission -->
-                            <td class="text-right text-xs">
-                                {{
-                                    format.formatCommissionRate(
-                                        v.commission?.commission_rates?.rate
-                                    )
-                                }}
-                            </td>
-                            <!-- 👉 Action -->
-                            <td class="text-center">
-                                <div
-                                    v-if="v.jailed"
-                                    class="badge badge-error gap-2 text-white"
-                                >
-                                {{ $t('staking.jailed') }}
-                                </div>
-                                <label
-                                    v-else
-                                    for="delegate"
-                                    class="btn btn-xs btn-primary rounded-sm capitalize"
-                                    @click="
-                                        dialog.open('delegate', {
-                                            validator_address:
-                                                v.operator_address,
-                                        })
-                                    "
-                                    >{{ $t('account.btn_delegate') }}</label
-                                >
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-
-            <div class="divider"></div>
-            <div class="flex flex-row items-center">
-                <div
-                    class="text-xs truncate relative py-2 px-4 rounded-md w-fit text-error mr-2"
-                >
-                    <span
-                        class="inset-x-0 inset-y-0 opacity-10 absolute bg-error"
-                    ></span>
-                    {{ $t('staking.top') }} 33%
-                </div>
-                <div
-                    class="text-xs truncate relative py-2 px-4 rounded-md w-fit text-warning"
-                >
-                    <span
-                        class="inset-x-0 inset-y-0 opacity-10 absolute bg-warning"
-                    ></span>
-                    {{ $t('staking.top') }} 67%
-                </div>
-                <div class="text-xs hidden md:!block pl-2">
-                    {{ $t('staking.description') }}
-                </div>
-            </div>
+                <!-- 👉 Voting Power -->
+                <td class="text-right">
+                  <div class="flex flex-col">
+                    <h6 class="text-sm font-weight-medium whitespace-nowrap">
+                      {{
+                        format.formatToken(
+                          {
+                            amount: parseInt(v.tokens).toString(),
+                            denom: staking.params.bond_denom,
+                          },
+                          true,
+                          '0,0'
+                        )
+                      }}
+                    </h6>
+                    <span class="text-xs">{{
+                      format.calculatePercent(
+                        v.delegator_shares,
+                        staking.totalPower
+                      )
+                    }}</span>
+                  </div>
+                </td>
+                <!-- 👉 24h Changes -->
+                <td class="text-right text-xs" :class="change24Color(v)">
+                  {{ change24Text(v) }}
+                </td>
+                <!-- 👉 commission -->
+                <td class="text-right text-xs">
+                  {{
+                    format.formatCommissionRate(
+                      v.commission?.commission_rates?.rate
+                    )
+                  }}
+                </td>
+                <!-- 👉 Action -->
+                <td class="text-center">
+                  <div
+                    v-if="v.jailed"
+                    class="badge badge-error gap-2 text-white"
+                  >
+                    {{ $t('staking.jailed') }}
+                  </div>
+                  <label
+                    v-else
+                    for="delegate"
+                    class="btn btn-xs btn-primary rounded-sm capitalize"
+                    @click="
+                      dialog.open('delegate', {
+                        validator_address: v.operator_address,
+                      })
+                    "
+                    >{{ $t('account.btn_delegate') }}</label
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
+
+        <div class="divider"></div>
+        <div class="flex flex-row items-center">
+          <div
+            class="text-xs truncate relative py-2 px-4 rounded-md w-fit text-error mr-2"
+          >
+            <span
+              class="inset-x-0 inset-y-0 opacity-10 absolute bg-error"
+            ></span>
+            {{ $t('staking.top') }} 33%
+          </div>
+          <div
+            class="text-xs truncate relative py-2 px-4 rounded-md w-fit text-warning"
+          >
+            <span
+              class="inset-x-0 inset-y-0 opacity-10 absolute bg-warning"
+            ></span>
+            {{ $t('staking.top') }} 67%
+          </div>
+          <div class="text-xs hidden md:!block pl-2">
+            {{ $t('staking.description') }}
+          </div>
+        </div>
+      </div>
     </div>
-</div>
+  </div>
 </template>
 
 <route>
@@ -503,7 +584,7 @@ loadAvatars();
 
 <style>
 .staking-table.table :where(th, td) {
-    padding: 8px 5px;
-    background: transparent;
+  padding: 8px 5px;
+  background: transparent;
 }
 </style>

--- a/src/modules/[chain]/staking/index.vue
+++ b/src/modules/[chain]/staking/index.vue
@@ -182,8 +182,13 @@ const list = computed(() => {
 });
 
 const apr = computed(() => {
-  return store.stats.find((stat) => stat.title === 'Staking APR')?.stats;
+  const formatter = useFormatter();
+  return formatter.formatDecimalToPercent(store.stakingApr.toString());
 });
+
+const calcActualApr = (apr: number, commission: number) => {
+  return apr * (1 - commission) * 100;
+};
 
 const fetchAvatar = (identity: string) => {
   // fetch avatar from keybase
@@ -409,6 +414,7 @@ loadAvatars();
                 <th scope="col" class="text-right uppercase">
                   {{ $t('staking.commission') }}
                 </th>
+                <th scope="col" class="text-right uppercase">ACTUAL APR</th>
                 <th scope="col" class="text-center uppercase">
                   {{ $t('staking.actions') }}
                 </th>
@@ -520,6 +526,9 @@ loadAvatars();
                       v.commission?.commission_rates?.rate
                     )
                   }}
+                </td>
+                <td class="text-right text-xs">
+                  {{ calcActualApr(store.stakingApr, Number(v.commission?.commission_rates?.rate) || 0).toFixed(2) }}%
                 </td>
                 <!-- 👉 Action -->
                 <td class="text-center">

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -16,7 +16,7 @@ router.beforeEach((to) => {
     if(chain){
       const blockchain= useBlockchain()
       if(chain !== blockchain.chainName) {
-        blockchain.setCurrent(chain.toString())
+        blockchain.setCurrent('hippo-protocol')
       }
     } 
 })

--- a/src/stores/useBaseStore.ts
+++ b/src/stores/useBaseStore.ts
@@ -2,124 +2,132 @@ import { defineStore } from 'pinia';
 import { useBlockchain } from '@/stores';
 import { decodeTxRaw, type DecodedTxRaw } from '@cosmjs/proto-signing';
 import dayjs from 'dayjs';
-import type { Block } from '@/types';
+import type { Block, BlocksByHeight } from '@/types';
 import { hashTx } from '@/libs';
 import { fromBase64 } from '@cosmjs/encoding';
 import { useRouter } from 'vue-router';
 
 export const useBaseStore = defineStore('baseStore', {
-    state: () => {
-        return {
-            earlest: {} as Block,
-            latest: {} as Block,
-            recents: [] as Block[],
-            theme: (window.localStorage.getItem('theme') || 'dark') as
-                | 'light'
-                | 'dark',
-            connected: true,
-        };
+  state: () => {
+    return {
+      earlest: {} as Block,
+      latest: {} as Block,
+      recents: [] as Block[],
+      theme: (window.localStorage.getItem('theme') || 'dark') as
+        | 'light'
+        | 'dark',
+      connected: true,
+      latestBlocks: {} as BlocksByHeight,
+    };
+  },
+  getters: {
+    blocktime(): number {
+      if (this.earlest && this.latest) {
+        if (
+          this.latest.block?.header?.height !==
+          this.earlest.block?.header?.height
+        ) {
+          const diff = dayjs(this.latest.block?.header?.time).diff(
+            this.earlest.block?.header?.time
+          );
+          const blocks =
+            Number(this.latest.block.header.height) -
+            Number(this.earlest.block.header.height);
+          return diff / blocks;
+        }
+      }
+      return 6000;
     },
-    getters: {
-        blocktime(): number {
-            if (this.earlest && this.latest) {
-                if (
-                    this.latest.block?.header?.height !==
-                    this.earlest.block?.header?.height
-                ) {
-                    const diff = dayjs(this.latest.block?.header?.time).diff(
-                        this.earlest.block?.header?.time
-                    );
-                    const blocks = Number(this.latest.block.header.height) - Number(this.earlest.block.header.height)
-                    return diff / (blocks);
-                }
-            }
-            return 6000;
-        },
-        blockchain() {
-            return useBlockchain();
-        },
-        currentChainId(): string {
-            return this.latest.block?.header.chain_id || '';
-        },
-        txsInRecents() {
-            const txs = [] as {
-                height: string;
-                hash: string;
-                tx: DecodedTxRaw;
-            }[];
-            this.recents.forEach((b) =>
-                b.block?.data?.txs.forEach((tx: string) => {
-                    if (tx) {
-                        const raw = fromBase64(tx);
-                        try {
-                            txs.push({
-                                height: b.block.header.height,
-                                hash: hashTx(raw),
-                                tx: decodeTxRaw(raw),
-                            });
-                        } catch (e) {
-                            console.error(e);
-                        }
-                    }
-                })
-            );
-            return txs.sort((a, b) => {return Number(b.height) - Number(a.height)});
-        },
+    blockchain() {
+      return useBlockchain();
     },
-    actions: {
-        async initial() {
-            this.fetchLatest()
-        },
-        async clearRecentBlocks() {
-            this.recents = [];
-        },
-        async fetchLatest() {
-            try{
-                this.latest = await this.blockchain.rpc?.getBaseBlockLatest();
-                this.connected = true
-            }catch(e) {
-                this.connected = false
+    currentChainId(): string {
+      return this.latest.block?.header.chain_id || '';
+    },
+    txsInRecents() {
+      const txs = [] as {
+        height: string;
+        hash: string;
+        tx: DecodedTxRaw;
+      }[];
+      this.recents.forEach((b) =>
+        b.block?.data?.txs.forEach((tx: string) => {
+          if (tx) {
+            const raw = fromBase64(tx);
+            try {
+              txs.push({
+                height: b.block.header.height,
+                hash: hashTx(raw),
+                tx: decodeTxRaw(raw),
+              });
+            } catch (e) {
+              console.error(e);
             }
-            if (
-                !this.earlest ||
-                this.earlest?.block?.header?.chain_id !=
-                    this.latest?.block?.header?.chain_id
-            ) {
-                //reset earlest and recents
-                this.earlest = this.latest;
-                this.recents = [];
-            }
-            //check if the block exists in recents
-            if (
-                this.recents.findIndex(
-                    (x) => x?.block_id?.hash === this.latest?.block_id?.hash
-                ) === -1
-            ) {
-                if (this.recents.length >= 50) {
-                    this.recents.shift();
-                }
-                this.recents.push(this.latest);
-            }
-            return this.latest;
-        },
+          }
+        })
+      );
+      return txs.sort((a, b) => {
+        return Number(b.height) - Number(a.height);
+      });
+    },
+  },
+  actions: {
+    async initial() {
+      this.fetchLatest();
+    },
+    async clearRecentBlocks() {
+      this.recents = [];
+    },
+    async fetchLatest() {
+      try {
+        this.latest = await this.blockchain.rpc?.getBaseBlockLatest();
+        this.connected = true;
+      } catch (e) {
+        this.connected = false;
+      }
+      if (
+        !this.earlest ||
+        this.earlest?.block?.header?.chain_id !=
+          this.latest?.block?.header?.chain_id
+      ) {
+        //reset earlest and recents
+        this.earlest = this.latest;
+        this.recents = [];
+      }
+      //check if the block exists in recents
+      if (
+        this.recents.findIndex(
+          (x) => x?.block_id?.hash === this.latest?.block_id?.hash
+        ) === -1
+      ) {
+        if (this.recents.length >= 50) {
+          this.recents.shift();
+        }
+        this.recents.push(this.latest);
+      }
+      return this.latest;
+    },
 
-        async fetchValidatorByHeight(height?: number, offset = 0) {
-            return this.blockchain.rpc.getBaseValidatorsetAt(
-                String(height),
-                offset
-            );
-        },
-        async fetchLatestValidators(offset = 0) {
-            return this.blockchain.rpc.getBaseValidatorsetLatest(offset);
-        },
-        async fetchBlock(height?: number | string) {
-            return this.blockchain.rpc.getBaseBlockAt(String(height));
-        },
-        async fetchAbciInfo() {
-            return this.blockchain.rpc.getBaseNodeInfo();
-        },
-        // async fetchNodeInfo() {
-        //     return this.blockchain.rpc.no()
-        // }
+    async fetchValidatorByHeight(height?: number, offset = 0) {
+      return this.blockchain.rpc.getBaseValidatorsetAt(String(height), offset);
     },
+    async fetchLatestValidators(offset = 0) {
+      return this.blockchain.rpc.getBaseValidatorsetLatest(offset);
+    },
+    async fetchBlock(height?: number | string) {
+      return this.blockchain.rpc.getBaseBlockAt(String(height));
+    },
+    async fetchAbciInfo() {
+      return this.blockchain.rpc.getBaseNodeInfo();
+    },
+    async fetchBlocks(minHeight: number | string, maxHeight: number | string) {
+      const res = await this.blockchain.rpc.getBlocksByHeight(
+        minHeight,
+        maxHeight
+      );
+      if (res.result) {
+        this.latestBlocks = res.result;
+      }
+    },
+  },
 });

--- a/src/stores/useBlockchain.ts
+++ b/src/stores/useBlockchain.ts
@@ -191,15 +191,7 @@ export const useBlockchain = defineStore('blockchain', {
         await this.dashboard.initial();
       }
 
-      // Find the case-sensitive name for the chainName, else simply use the parameter-value.
-      const caseSensitiveName = 
-        Object.keys(this.dashboard.chains).find((x) => x.toLowerCase() === name.toLowerCase()) 
-        || name;
-
-      // Update chainName if needed
-      if (caseSensitiveName !== this.chainName) {
-        this.chainName = caseSensitiveName;
-      }
+      this.chainName = 'hippo-protocol';
     },
     supportModule(mod: string) {
       return !this.current?.features || this.current.features.includes(mod);

--- a/src/stores/useBlockchain.ts
+++ b/src/stores/useBlockchain.ts
@@ -31,7 +31,7 @@ export const useBlockchain = defineStore('blockchain', {
     return {
       status: {} as Record<string, string>,
       rest: '',
-      chainName: '',
+      chainName: 'hippo-protocol',
       endpoint: {} as {
         type?: EndpointType;
         address: string;

--- a/src/stores/useDashboard.ts
+++ b/src/stores/useDashboard.ts
@@ -363,17 +363,7 @@ export const useDashboard = defineStore('dashboard', {
     setupDefault() {
       if (this.length > 0) {
         const blockchain = useBlockchain();
-        const keys = Object.keys(this.favoriteMap)
-        for (let i = 0; i < keys.length; i++) {
-          if (!blockchain.chainName && this.chains[keys[i]] && this.favoriteMap[keys[i]]) {
-            blockchain.setCurrent(keys[i]);
-            break
-          }
-        }
-        if (!blockchain.chainName) {
-          const [first] = Object.keys(this.chains);
-          blockchain.setCurrent(first);
-        }
+        blockchain.setCurrent('hippo-protocol');
         this.loadingPrices()
       }
     },

--- a/src/stores/useFormatter.ts
+++ b/src/stores/useFormatter.ts
@@ -314,6 +314,14 @@ export const useFormatter = defineStore('formatter', {
       );
       return validator?.description?.moniker;
     },
+    validatorFromHex(address:string){
+      if (!address) return address;
+
+      const validator = this.staking.validators.find(
+        (x) => consensusPubkeyToHexAddress(x.consensus_pubkey) === address.toUpperCase()
+      );
+      return validator?.description?.moniker;
+    },
     // find validator by operator address
     validatorFromBech32(address: string) {
       if (!address) return address;

--- a/src/stores/useGovStore.ts
+++ b/src/stores/useGovStore.ts
@@ -9,6 +9,7 @@ export const useGovStore = defineStore('govStore', {
   state: () => {
     return {
       params: {
+        all: {},
         deposit: {},
         voting: {},
         tally: {},
@@ -29,7 +30,7 @@ export const useGovStore = defineStore('govStore', {
     initial() {
       this.$reset();
       this.fetchParams();
-      this.fetchProposals('2');
+      this.fetchProposals('0');
     },
     async fetchProposals(status: string, pagination?: PageRequest) {
       //if (!this.loading[status]) {
@@ -39,14 +40,14 @@ export const useGovStore = defineStore('govStore', {
       );
 
       //filter spam proposals
-      if(proposals?.proposals) {
+      if (proposals?.proposals) {
         proposals.proposals = proposals.proposals.filter((item) => {
-          const title = item.content?.title || item.title || ""
-          return title.toLowerCase().indexOf("airdrop")===-1
+          const title = item.content?.title || item.title || '';
+          return title.toLowerCase().indexOf('airdrop') === -1;
         });
       }
 
-      if (status === '2') {
+      if (status === '0' || status === '2') {
         proposals?.proposals?.forEach((item) => {
           this.fetchTally(item.proposal_id).then((res) => {
             item.final_tally_result = res?.tally;
@@ -58,17 +59,18 @@ export const useGovStore = defineStore('govStore', {
                 this.walletstore.currentAddress
               )
                 .then((res) => {
-                  item.voterStatus = res?.vote?.option || 'VOTE_OPTION_NO_WITH_VETO'
+                  item.voterStatus =
+                    res?.vote?.option || 'VOTE_OPTION_NO_WITH_VETO';
                   // 'No With Veto';
                 })
                 .catch((reject) => {
-                  item.voterStatus = 'VOTE_OPTION_NO_WITH_VETO'
+                  item.voterStatus = 'VOTE_OPTION_NO_WITH_VETO';
                 });
             } catch (error) {
-              item.voterStatus = 'VOTE_OPTION_NO_WITH_VETO'
+              item.voterStatus = 'VOTE_OPTION_NO_WITH_VETO';
             }
           } else {
-            item.voterStatus = 'VOTE_OPTION_NO_WITH_VETO'
+            item.voterStatus = 'VOTE_OPTION_NO_WITH_VETO';
           }
         });
       }

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -101,3 +101,32 @@ export interface PaginatedTendermintValidator {
     validators: TendermintValidator[],
     block_height: string
 }
+
+export interface BlocksByHeight{
+    last_height:string;
+    block_metas:{
+        block_id: BlockId,
+        block_size: string,
+        num_txs: string,
+        header: {
+            version: {
+                block: string,
+                app: string
+            },
+            chain_id: string,
+            height: string,
+            time: string,
+            last_block_id: BlockId,
+            last_commit_hash: string,
+            data_hash: string,
+            validators_hash: string,
+            next_validators_hash: string,
+            consensus_hash: string,
+            app_hash: string,
+            last_results_hash: string,
+            evidence_hash: string,
+            proposer_address: string,
+        }
+    }[]
+   
+}


### PR DESCRIPTION
- Blocks page to show multiple blocks sorted by latest.
- Show exact vote amount for governance proposals.
- Add all proposals tab for not fully deposited proposals.
- Add staking APR for chain, and for each validators(affected by fees) - @ChrisCho-H I'm not sure the calculation method is correct. `APR = Inflation * (Total supply / Total staked) * (1 - Community tax)`
- Always shows hippo-protocol for other chain routes (temporarily solution)