### PR TITLE
Fix connection of widget

### DIFF
--- a/src/modules/[chain]/gov/index.vue
+++ b/src/modules/[chain]/gov/index.vue
@@ -46,7 +46,8 @@ function page(p: number) {
         <a class="tab text-gray-400 uppercase" :class="{ 'tab-active': tab === '4' }" @click="changeTab('4')">{{
           $t('gov.rejected') }}</a>
       </div>
-      <button class="btn btn-secondary btn-sm text-white uppercase" @click="dialog.open('propose', {})">Propose</button>
+      <label for='propose' class="btn btn-secondary btn-sm text-white uppercase"
+        @click="dialog.open('propose', {})">Propose</label>
     </div>
     <ProposalListItem :proposals="store?.proposals[tab]" />
     <PaginationBar :total="store?.proposals[tab]?.pagination?.total" :limit="pageRequest.limit" :callback="page" />


### PR DESCRIPTION
It seems connection of widget is done when `for `property of \<label\> is same with widget's `id`